### PR TITLE
cloudinitiso.exe の実行前に出力先ディレクトリを作成

### DIFF
--- a/launch.ps1
+++ b/launch.ps1
@@ -12,6 +12,7 @@ $vmPath = "${Env:Public}\Documents\Hyper-V\$VMName"
 $vhdx = "$($vmPath)\test.vhdx"
 $cloudInitIso = "$($vmPath)\metadata.iso"
 
+New-Item "$vmPath" -type directory -Force | Out-Null
 & .\cloudinitiso.exe -iso $cloudInitIso
 
 # Download qemu-img from http://www.cloudbase.it/qemu-img-windows/


### PR DESCRIPTION
`launch.ps1` を実行してVMの作成を試みましたが、`cloudinitiso.exe`の実行に失敗してスクリプトが完走しませんでした。
このパッチは上記の問題を修正します。

## 問題の詳細
* 初回の実行時に `cloudinitiso.exe` の実行に失敗する
    * この時点では出力先の `$vmPath` ディレクトリが存在しないため

## 変更点
* `cloudinitiso.exe` の実行前に `$vmPath` ディレクトリを作成 (`New-Item -Force`)
    *  作成するディレクトリが既に存在する場合、特に何も変更しない
